### PR TITLE
/bin zu gitignore hinzugefügt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**
+/bin
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
Kleiner Fix der durch die IDE entstanden ist